### PR TITLE
compare intValues not Integer objects

### DIFF
--- a/src/main/java/org/geppetto/model/util/PointerUtility.java
+++ b/src/main/java/org/geppetto/model/util/PointerUtility.java
@@ -318,7 +318,7 @@ public class PointerUtility
 	{
 		boolean sameType = pointer.getType() == pointer2.getType() || pointer.getType().equals(pointer2.getType());
 		boolean sameVar = pointer.getVariable() == pointer2.getVariable() || pointer.getVariable().equals(pointer2.getVariable());
-		boolean sameIndex = pointer.getIndex() == pointer2.getIndex();
+		boolean sameIndex = pointer.getIndex().intValue() == pointer2.getIndex().intValue();
 		return sameType && sameVar && sameIndex;
 	}
 


### PR DESCRIPTION
this bug is by nature nondeterministic but if you want to check it out, try something with a decent number of cells ([eg.](http://www.opensourcebrain.org/projects/opencortex/models?explorer=https%253A%252F%252Fraw.githubusercontent.com%252FOpenSourceBrain%252FOpenCortex%252Fmaster%252Fexamples%252FBalanced_240cells_36926conns.net.nml)), then get the experiment state and map over the variables with `getTimeSeries`… some will be `undefined` even though traces exist for all cells because `getIndex` (see diff) returns an `Integer` so `==` will be false if the JVM happens to create a different Integer object to represent the same value…